### PR TITLE
Make group a parameter.

### DIFF
--- a/nuxeo-labs-user-registration-core/src/main/java/org/nuxeo/user/registration/automation/InviteUserOp.java
+++ b/nuxeo-labs-user-registration-core/src/main/java/org/nuxeo/user/registration/automation/InviteUserOp.java
@@ -39,6 +39,9 @@ public class InviteUserOp {
     @Param(name = "comment", required = false)
     protected String comment;
 
+    @Param(name = "group", required = false)
+    protected String group= "members";
+
     @Param(name = "Output Variable", required = true)
     protected String outputVariable;
 
@@ -50,7 +53,7 @@ public class InviteUserOp {
         invitation.setPropertyValue(config.getUserInfoFirstnameField(), doc.getPropertyValue("user_registration:first_name"));
         invitation.setPropertyValue(config.getUserInfoLastnameField(), doc.getPropertyValue("user_registration:last_name"));
         invitation.setPropertyValue(config.getUserInfoEmailField(),  doc.getPropertyValue("user_registration:email"));
-        invitation.setPropertyValue(config.getUserInfoGroupsField(), new String[]{"members"});
+        invitation.setPropertyValue(config.getUserInfoGroupsField(), new String[]{group});
         //invitation.setPropertyValue(config.getUserInfoTenantIdField(), user.getTenantId());
         invitation.setPropertyValue(config.getUserInfoCompanyField(), doc.getPropertyValue("user_registration:email"));
         invitation.setPropertyValue("registration:comment", comment);


### PR DESCRIPTION
Self-registration fails if the passed group doesn't exist. The default is now "members" and you can pass a different group as a param to the operation.